### PR TITLE
Fixed Blob Sink and Source Datatype Bug

### DIFF
--- a/grc/azure_software_radio_blob_sink.block.yml
+++ b/grc/azure_software_radio_blob_sink.block.yml
@@ -32,10 +32,10 @@ parameters:
 - id: type
   label: Input Type
   dtype: enum
-  options: [                 fc32,          sc16,          sc8,        f32,      s32,      s16,       s8]
-  option_labels: [Complex float32, Complex int16, Complex int8,      float,      int,    short,     byte]
+  options: [            fc32,        f32,      s32,      s16,       s8]
+  option_labels: [   complex,      float,      int,    short,     byte]
   option_attributes:
-      np_type: [     np.complex64,      np.int32,     np.int16, np.float32, np.int32, np.int16, np.ubyte]
+      np_type: [np.complex64, np.float32, np.int32, np.int16, np.ubyte]
   hide: part
 - id: vlen
   label: Vector Length

--- a/grc/azure_software_radio_blob_source.block.yml
+++ b/grc/azure_software_radio_blob_source.block.yml
@@ -27,10 +27,10 @@ parameters:
 - id: type
   label: Output Type
   dtype: enum
-  options: [                 fc32,          sc16,          sc8,        f32,      s32,      s16,       s8]
-  option_labels: [Complex float32, Complex int16, Complex int8,      float,      int,    short,     byte]
+  options: [            fc32,        f32,      s32,      s16,       s8]
+  option_labels: [   complex,      float,      int,    short,     byte]
   option_attributes:
-      np_type: [     np.complex64,      np.int32,     np.int16, np.float32, np.int32, np.int16, np.ubyte]
+      np_type: [np.complex64, np.float32, np.int32, np.int16, np.ubyte]
   hide: part
 - id: vlen
   label: Vector Length

--- a/python/blob_sink.py
+++ b/python/blob_sink.py
@@ -98,15 +98,15 @@ class BlobSink(gr.sync_block):
         if sigmf:
             meta_blob_client = self.blob_service_client.get_blob_client(container=container_name,
                                                                         blob=blob_name + '.sigmf-meta')
-            if np_dtype == np.complex64:
+            if np_dtype == np.complex64: # complex
                 datatype_str = 'cf32_le'
-            elif np_dtype == np.float32:
+            elif np_dtype == np.float32: # float
                 datatype_str = 'rf32_le'
-            elif np_dtype == np.int32: # See https://github.com/microsoft/azure-software-radio/issues/67
-                datatype_str = 'ci16_le'
-            elif np_dtype == np.int16:
+            elif np_dtype == np.int32: # int
+                datatype_str = 'ri32_le'
+            elif np_dtype == np.int16: # short
                 datatype_str = 'ri16_le'
-            elif np_dtype == np.ubyte:
+            elif np_dtype == np.ubyte: # byte
                 datatype_str = 'ru8'
             else:
                 raise ValueError

--- a/python/blob_source.py
+++ b/python/blob_source.py
@@ -29,8 +29,7 @@ class BlobSource(gr.sync_block):
     supported by the DefaultAzureCredential class, such as environment variables, a
     managed identity, the az login command, etc.
 
-    This block currently only supports complex64 inputs and has only been tested with block blobs.
-    Page blobs and append blobs are not supported.
+    This block works with block blobs (page blobs and append blobs are not supported).
 
     Args:
     Output Type: Data type of the sample stream


### PR DESCRIPTION
Fixes #9 

We attempted to implement complex int and complex short, which are not actually used much in GR (e.g., little to no other blocks actually use them) but it was implemented using the wrong numpy-to-GR datatype conversion, e.g. assigning complex ints to a single float32.  So I just removed those 2 options, and then updated the docs, there were no tests to remove since we never made a test for those datatypes anyway.  Existing unit tests still pass and I played around with both the source and sink, seem to work fine still.

TLDR- Blob Sink/Source now resemble File Sink/Source in terms of supported datatypes, and no more buggy datatype options

![image](https://user-images.githubusercontent.com/5722532/169437153-aef8d6d3-1d0a-4d4f-9087-d4af7fa439a7.png)
