### PR TITLE
Created SigMF Blob Source/Sink Wrapper Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For information on our GNU Radio developer VM available in Azure, see [this guid
 - [Examples](#examples)
 - [Blocks Documentation](#azure-software-radio-out-of-tree-module-blocks)
   - [Key Vault Block](#key-vault-block)
-  - [Blob Blocks](#blob-blocks)
+  - [Blob (incl. SigMF) Blocks](#blob-blocks)
   - [Event Hub Blocks](#event-hub-blocks)
   - [DIFI Blocks using the IEEE-ISTO Std 4900-2021: Digital IF Interoperability Standard](#difi-blocks-using-the-ieee-isto-std-4900-2021-digital-if-interoperability-standard)
   - [REST API Block](#rest-api-block)
@@ -110,13 +110,14 @@ For a brief tutorial on using this block, see the [Key Vault Example](./examples
 
 ### Blob Blocks
 The two Blob blocks (source and sink) provide an interface to read and write samples to [Azure Blob storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) in GNU Radio.
+Note that the SigMF Blob Source/Sink are simply wrappers around the regular Blob Source/Sink with SigMF mode set to True.
 It is expected that the user will setup a storage account and a container prior to accessing Blob storage with the Blob source and sink blocks. To create a storage account, see [Create Storage Account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal).
 
- * __Blob Source Block__\
-	The Blob source block reads samples from Azure Blob storage. This block currently supports block blobs and the following outputs: Complex float32, Complex int16, Complex int8, float, int, short and byte (Page blobs and append blobs are not supported at this time).
+ * __Blob Source Block & SigMF Blob Source Block__\
+	The Blob source block reads samples from Azure Blob storage. This block currently supports block blobs and the following outputs: complex, float, int, short and byte (Page blobs and append blobs are not supported at this time).
 
- * __Blob Sink Block__\
-	The Blob sink block writes samples to Azure Blob storage. This block currently supports block blobs and the following inputs:  Complex float32, Complex int16, Complex int8, float, int, short and byte (Page blobs and append blobs are not supported at this time).
+ * __Blob Sink Block & SigMF Blob Sink Block__\
+	The Blob sink block writes samples to Azure Blob storage. This block currently supports block blobs and the following inputs:  complex, float, int, short and byte (Page blobs and append blobs are not supported at this time).
 
 There are several ways to authenticate to the Azure blob backend, these blocks support authentication using a connection string, a URL with an embedded SAS token, or use credentials supported by the DefaultAzureCredential class.
 

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -13,6 +13,8 @@ install(FILES
     azure_software_radio_difi_sink_cpp.block.yml
     azure_software_radio_blob_sink.block.yml
     azure_software_radio_blob_source.block.yml
+    azure_software_radio_sigmf_blob_sink.block.yml
+    azure_software_radio_sigmf_blob_source.block.yml
     azure_software_radio_eventhub_sink.block.yml
     azure_software_radio_eventhub_source.block.yml
     azure_software_radio_rest_api.block.yml DESTINATION share/gnuradio/grc/blocks

--- a/grc/azure_software_radio_sigmf_blob_sink.block.yml
+++ b/grc/azure_software_radio_sigmf_blob_sink.block.yml
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the GNU General Public License v3.0 or later.
+# See License.txt in the project root for license information.
+#
+
+id: azure_software_radio_sigmf_blob_sink
+label: SigMF Blob Sink
+category: '[Azure software radio]'
+
+templates:
+  imports:  |-
+    import azure_software_radio
+    import numpy as np
+  make: azure_software_radio.BlobSink(${type.np_type},
+                                      ${vlen},
+                                      ${authentication_method},
+                                      ${connection_str},
+                                      ${url},
+                                      ${container_name},
+                                      ${blob_name},
+                                      ${block_len},
+                                      ${queue_size},
+                                      ${retry_total},
+                                      True,
+                                      ${sample_rate},
+                                      ${center_freq},
+                                      ${author},
+                                      ${description},
+                                      ${hw_info})
+
+parameters:
+- id: type
+  label: Input Type
+  dtype: enum
+  options: [                 fc32,          sc16,          sc8,        f32,      s32,      s16,       s8]
+  option_labels: [Complex float32, Complex int16, Complex int8,      float,      int,    short,     byte]
+  option_attributes:
+      np_type: [     np.complex64,      np.int32,     np.int16, np.float32, np.int32, np.int16, np.ubyte]
+  hide: part
+- id: vlen
+  label: Vector Length
+  dtype: int
+  default: '1'
+  hide: ${ 'part' if vlen == 1 else 'none' }
+- id: authentication_method
+  label: Auth Method
+  dtype: string
+  default: 'default'
+  options: ['connection_string', 'url_with_sas', 'default']
+- id: connection_str
+  label: Connection String
+  dtype: string
+  default: ''
+  hide: ${'all' if authentication_method != 'connection_string' else 'none'}
+- id: url
+  label: URL
+  dtype: string
+  default: ''
+  hide: ${'all' if authentication_method == 'connection_string' else 'none'}
+- id: container_name
+  label: Container Name
+  dtype: string
+  default: ''
+- id: blob_name
+  label: Blob Name
+  dtype: string
+  default: ''
+- id: block_len
+  label: Blob Block Length
+  dtype: int
+  default: 500000
+- id: queue_size
+  label: Queue size
+  dtype: int
+  default: 4
+  hide: 'all'
+- id: retry_total
+  label: Retry Total
+  dtype: int
+  default: 10
+- id: sample_rate
+  label: Sample Rate
+  dtype: float
+  default: samp_rate
+- id: center_freq
+  label: Center Frequency
+  dtype: float
+  options: [np.nan]
+  option_labels: ['None']
+- id: author
+  label: Author
+  dtype: string
+  default: ''
+- id: description
+  label: Description
+  dtype: string
+  default: ''
+- id: hw_info
+  label: Hardware Info
+  dtype: string
+  default: ''
+
+inputs:
+- label: in
+  domain: stream
+  dtype: ${type}
+  vlen: ${vlen}
+
+documentation: |-
+    Note - This block is simply a wrapper around Blob Sink with SigMF mode set to True.
+
+file_format: 1

--- a/grc/azure_software_radio_sigmf_blob_source.block.yml
+++ b/grc/azure_software_radio_sigmf_blob_source.block.yml
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the GNU General Public License v3.0 or later.
+# See License.txt in the project root for license information.
+#
+
+id: azure_software_radio_sigmf_blob_source
+label: SigMF Blob Source
+category: '[Azure software radio]'
+
+templates:
+  imports:  |-
+    import azure_software_radio
+    import numpy as np
+  make: azure_software_radio.BlobSource(${type.np_type},
+                                        ${vlen},
+                                        ${authentication_method},
+                                        ${connection_str},
+                                        ${url},
+                                        ${container_name},
+                                        ${blob_name},
+                                        ${queue_size},
+                                        ${retry_total},
+                                        ${repeat},
+                                        True)
+
+parameters:
+- id: type
+  label: Output Type
+  dtype: enum
+  options: [                 fc32,          sc16,          sc8,        f32,      s32,      s16,       s8]
+  option_labels: [Complex float32, Complex int16, Complex int8,      float,      int,    short,     byte]
+  option_attributes:
+      np_type: [     np.complex64,      np.int32,     np.int16, np.float32, np.int32, np.int16, np.ubyte]
+  hide: part
+- id: vlen
+  label: Vector Length
+  dtype: int
+  default: '1'
+  hide: ${ 'part' if vlen == 1 else 'none' }
+- id: authentication_method
+  label: Auth Method
+  dtype: string
+  default: 'default'
+  options: ['connection_string', 'url_with_sas', 'default', 'none']
+- id: connection_str
+  label: Connection String
+  dtype: string
+  default: ''
+  hide: ${'all' if authentication_method != 'connection_string' else 'none'}
+- id: url
+  label: URL
+  dtype: string
+  default: ''
+  hide: ${'all' if authentication_method == 'connection_string' else 'none'}
+- id: container_name
+  label: Container Name
+  dtype: string
+  default: ''
+- id: blob_name
+  label: Blob Name
+  dtype: string
+  default: ''
+- id: queue_size
+  label: Queue size
+  dtype: int
+  default: 4
+  hide: 'all'
+- id: retry_total
+  label: Retry Total
+  dtype: int
+  default: 10
+- id: repeat
+  label: Repeat
+  dtype: enum
+  default: 'False'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+
+outputs:
+- label: out
+  domain: stream
+  dtype: ${type}
+  vlen: ${vlen}
+
+documentation: |-
+    Note - This block is simply a wrapper around Blob Source with SigMF mode set to True.
+
+file_format: 1


### PR DESCRIPTION
They are just yaml blocks that wrap Blob Source and Sink, setting SigMF mode to True.  The main motivation behind having these blocks is so people are more aware of the SigMF functionality, e.g., if they look through the list of gr-azure blocks, otherwise they would have to dig through the Blob block docs to find out about it.  GNU Radio itself did something very similar with the SigMF Minimal Blocks it added recently.

No additional automated testing needed

One thing I did was edit the docs part of the yaml so that the following note will show up above the actual blob block docs (which live in the python, which gets reused for these two new blocks):

![image](https://user-images.githubusercontent.com/5722532/169441844-10316265-3f14-4023-be9d-a8a0999dacbb.png)
