### PR TITLE
REST Block now uses config in place of call and you no longer include set_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build*/
 examples/grc/*.py
 .venv/*
+examples/rest_example.py

--- a/examples/example_REST_calls.http
+++ b/examples/example_REST_calls.http
@@ -1,0 +1,11 @@
+PUT http://127.0.0.1:8000/config HTTP/1.1
+content-type: application/json
+
+{
+    "freq": 100
+}
+
+###
+
+GET http://127.0.0.1:8000/status HTTP/1.1
+content-type: application/json

--- a/examples/rest_api_quickstart.md
+++ b/examples/rest_api_quickstart.md
@@ -1,11 +1,10 @@
 # Quickstart: Running the REST API example
 
-The REST API block exposes top block parameters in GNU Radio via REST such as variables and functions to enable getting status from a running flowgraph and dynamically change settings.
+The REST API block exposes top block parameters in GNU Radio via REST such as variables and parameters to enable getting status from a running flowgraph and dynamically change settings.
 
 The block supports the following routes:
 - `/status`: returns the readable settings
-- `/config`: updates the writable variables with the specified configuration values
-- `/call`: executes the writable functions with the specified parameters
+- `/config`: updates the writable variables/parameters with the specified configuration values
 
 ## Prerequisites
 
@@ -18,7 +17,7 @@ Open [rest-example.grc](../examples/rest_example.grc)
 
 The flowgraph starts a REST server in Port 8000 and sets the readable and writable/callable settings.
 - Readable settings that are exposed via the REST endpoint when calling `http://<addr>:8000/status` are: `samp_rate, amplitude, freq and phase`.
-- Callable functions that are exposed via the REST endpoint when calling `http://<addr>:8000/call` are: `set_amplitude, set_freq`. These functions allow to modify the signal amplitude and frequency during runtime.
+- Callable functions that are exposed via the REST endpoint when calling `http://<addr>:8000/config` are: `amplitude, freq`. These functions allow to modify the signal amplitude and frequency during runtime.
 
 Run the flowgraph and you should see the QT GUI Sink blocks showing the default amplitude and frequency values of the generated signal.
 
@@ -28,7 +27,7 @@ To get the status of the running example using curl run the following command:
 ```curl -X GET http://127.0.0.1:8000/status```
 
 The signal amplitude and frequency can be updated as follows:
-```curl -X PUT http://127.0.0.1:8000/call -H 'Content-Type: application/json' -d '{"set_amplitude":2, "set_freq":10e3}'```
+```curl -X PUT http://127.0.0.1:8000/config -H 'Content-Type: application/json' -d '{"amplitude":2, "freq":10e3}'```
 
 Confirm the new settings by looking at the QT Sink blocks or getting the status again.
 

--- a/examples/rest_example.grc
+++ b/examples/rest_example.grc
@@ -23,6 +23,7 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: REST Configurable Signal Generator
+    window_size: (1000,1000)
   states:
     bus_sink: false
     bus_source: false
@@ -68,20 +69,20 @@ blocks:
     coordinate: [456, 12.0]
     rotation: 0
     state: enabled
-- name: rest_api_0
+- name: rest_api_1
   id: rest_api
   parameters:
     alias: ''
     comment: ''
     port: '8000'
-    readable: '[''samp_rate'', ''freq'', ''amplitude'', ''phase'']'
+    readable: '[''freq'', ''amplitude'', ''phase'']'
     value: '0'
-    writable: '[''set_freq'', ''set_amplitude'']'
+    writable: '[''freq'', ''amplitude'', ''phase'']'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [40, 116.0]
+    coordinate: [88, 140.0]
     rotation: 0
     state: true
 - name: samp_rate
@@ -141,16 +142,16 @@ blocks:
   id: note
   parameters:
     alias: ''
-    comment: ''
-    note: 'This flowgraph settings can be read and updated using the REST endpoint.
-      Read the flowgraph settings using curl -X GET http://<IP>:8000/status. To update
-      the writable settings use curl -X PUT http://<IP>:8000/call -H ''Content-Type:
-      application/json'' -d ''{"set_amplitude":2, "set_freq":2e3}'' '
+    comment: "This flowgraph settings can be read and updated using the REST endpoint.\n\
+      Read the flowgraph settings using:\n   curl -X GET http://127.0.0.1:8000/status\n\
+      To update the writable settings use\n   curl -X PUT http://127.0.0.1:8000/config\
+      \ -H 'Content-Type: application/json' -d '{\"amplitude\":2, \"freq\":2e3}'"
+    note: ''
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [48, 212.0]
+    coordinate: [544, 28.0]
     rotation: 0
     state: true
 - name: qtgui_time_sink_x_0

--- a/grc/azure_software_radio_rest_api.block.yml
+++ b/grc/azure_software_radio_rest_api.block.yml
@@ -12,8 +12,10 @@ parameters:
     default: 8000
 -   id: readable
     dtype: raw
+    default: ['samp_rate']
 -   id: writable
     dtype: raw
+    default: ['samp_rate']
 
 value: ${value}
 templates:
@@ -25,26 +27,26 @@ templates:
 
 documentation: |
 
-    Creates REST endpoints to get flowgrpah status, get/set variables, and trigger callbacks.
+    Creates REST endpoints to get flowgraph status, get/set variables (by triggering their callbacks).
 
         The following routes are supported (no authentication is used):
             - GET http://hostname:<port>/status
-            - GET http://hostname:<port>/config
             - PUT http://hostname:<port>/config
-            - PUT http://hostname:<port>/call
 
     Args:
         Port: The desired server listening port.
-        Read Only Settings: List of allowable read-only settings (variables) in the top block.
-        Write Only Settings: List of allowable write-only settings (variables and/or callbacks) in the top block.
+        Read Only Settings: List of allowable read-only settings (variables/params) in top block.
+        Write Only Settings: List of allowable write-only settings (variables/params callbacks) in top block.
 
     Example:
-        Port: 8080
+        Port: 8000
         Read Only Settings: ['samp_rate', 'freq']
         Write Only Settings: ['freq']
 
-        curl -X GET http://<IP>:8080/status
+        The above would start a server at port 8000 and expose the sample rate and freq in the top block as a readable status, and freq as writable.
+        You could then use the following REST calls to get the values and set freq
 
-        The above would start a server at port 8080 and expose the sample rate in the top block as a readable status.
+        curl -X GET http://127.0.0.1:8000/status
+        curl -X PUT http://127.0.0.1:8000/config -H 'Content-Type: application/json' -d '{"amplitude":2, "freq":2e3}'
 
 file_format: 1

--- a/grc/azure_software_radio_rest_api.block.yml
+++ b/grc/azure_software_radio_rest_api.block.yml
@@ -30,8 +30,9 @@ documentation: |
     Creates REST endpoints to get flowgraph status, get/set variables (by triggering their callbacks).
 
         The following routes are supported (no authentication is used):
-            - GET http://hostname:<port>/status
-            - PUT http://hostname:<port>/config
+            - GET  http://hostname:<port>/status
+            - PUT  http://hostname:<port>/config
+            - POST http://hostname:<port>/config (functionally equivalent to the above)
 
     Args:
         Port: The desired server listening port.

--- a/python/qa_rest_api.py
+++ b/python/qa_rest_api.py
@@ -7,7 +7,6 @@
 # See License.txt in the project root for license information.
 #
 
-import ast
 import time
 
 from socket import socket

--- a/python/qa_rest_api.py
+++ b/python/qa_rest_api.py
@@ -30,11 +30,11 @@ class QaRestApi(gr_unittest.TestCase):
         instance = RestApi(self, port)
         self.assertIsNotNone(instance)
 
-    def update_var(self, val):
-        self.val = val
+    def set_var1(self, val):
+        self.var1 = val
 
-    def update_var1(self, val):
-        self.val1 = val
+    def set_var2(self, val):
+        self.var2 = val
 
     def test_get_status(self):
         self.check_var1 = 1
@@ -53,89 +53,31 @@ class QaRestApi(gr_unittest.TestCase):
             self.assertEqual(check_str in dict_str, True)
         self.assertEqual('fake_var' in dict_str, False)
 
-    def test_get_config(self):
-        self.pi_val = 3.14
-        self.pi_copy = self.pi_val
+    def test_config_by_name(self):
+        self.var1 = None
+        self.var2 = None
         port = self.get_free_port()
-        instance = RestApi(self, port, write_settings=['pi_val'])
+        instance = RestApi(self, port, write_settings=['var1', 'var2'])
         # give server a second to startup
         time.sleep(1)
+        self.var1 = 0
+        self.var2 = 0
         addr_str = 'http://127.0.0.1:' + str(port) + '/config'
-        resp = httpx.Client().get(addr_str)
+        resp = httpx.Client().put(addr_str, json={"var1": 3.14, "var2": 5.0})
         self.assertIsNotNone(resp)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        dict_str = resp.content.decode("UTF-8")
-        res_dict = ast.literal_eval(dict_str)
-        self.assertEqual(res_dict['pi_val'], self.pi_val)
-        self.assertEqual('pi_copy' in dict_str, False)
+        self.assertEqual(self.var1, 3.14)
+        self.assertEqual(self.var2, 5.0)
 
-    def test_put_config(self):
-        self.pi_val = 0
-        self.test_int = 1
+    def test_bad_config_by_name(self):
+        self.var1 = None
         port = self.get_free_port()
-        instance = RestApi(self, port, read_settings=['pi_val', 'test_int'], write_settings=['pi_val'])
+        instance = RestApi(self, port, write_settings=['var1'])
         # give server a second to startup
         time.sleep(1)
+        self.var1 = 0
         addr_str = 'http://127.0.0.1:' + str(port) + '/config'
-        resp = httpx.Client().put(addr_str, json={"pi_val": 3.14})
-        self.assertIsNotNone(resp)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        dict_str = resp.content.decode("UTF-8")
-        res_dict = ast.literal_eval(dict_str)
-        self.assertEqual(res_dict['pi_val'], 3.14)
-
-    def test_call_by_name(self):
-        self.val = None
-        port = self.get_free_port()
-        instance = RestApi(self, port, write_settings=['update_var', 'update_var1'])
-        # give server a second to startup
-        time.sleep(1)
-        self.val = 0
-        self.val1 = 0
-        addr_str = 'http://127.0.0.1:' + str(port) + '/call'
-        resp = httpx.Client().put(addr_str, json={"update_var": 3.14, "update_var1": 5.0})
-        self.assertIsNotNone(resp)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(self.val, 3.14)
-        self.assertEqual(self.val1, 5.0)
-
-    def test_unauthorized_put_config(self):
-        self.pi_val = 0
-        port = self.get_free_port()
-        instance = RestApi(self, port, read_settings=['pi_val'])
-        # give server a second to startup
-        time.sleep(1)
-        addr_str = 'http://127.0.0.1:' + str(port) + '/config'
-        with httpx.Client() as client:
-            resp = client.put(addr_str, json={"pi_val": 3.14})
-            self.assertIsNotNone(resp)
-            self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
-            dict_str = resp.content.decode("UTF-8")
-            self.assertEqual('pi_val' in dict_str, False)
-
-    def test_bad_put_config(self):
-        self.pi_val = 0
-        port = self.get_free_port()
-        instance = RestApi(self, port, read_settings=['pi_val'], write_settings=['pi_val'])
-        # give server a second to startup
-        time.sleep(1)
-        addr_str = 'http://127.0.0.1:' + str(port) + '/config'
-        with httpx.Client() as client:
-            resp = client.put(addr_str, json={"fake_val": 0})
-            self.assertIsNotNone(resp)
-            self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-            dict_str = resp.content.decode("UTF-8")
-            self.assertEqual('Error' in dict_str, True)
-
-    def test_bad_call_by_name(self):
-        self.val = None
-        port = self.get_free_port()
-        instance = RestApi(self, port, write_settings=['update_var'])
-        # give server a second to startup
-        time.sleep(1)
-        self.val = 0
-        addr_str = 'http://127.0.0.1:' + str(port) + '/call'
-        resp = httpx.Client().put(addr_str, json={"update_var2":3.14})
+        resp = httpx.Client().put(addr_str, json={"var2":3.14}) # request a var/param that wasnt exposed
         self.assertIsNotNone(resp)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/python/rest_api.py
+++ b/python/rest_api.py
@@ -47,6 +47,7 @@ class RestApi(gr.basic_block):
             return read_status
 
         @app.put("/config")
+        @app.post("/config")
         def call_by_name(callbacks: dict):
             """
             Executes a callable/writable function in the top block

--- a/python/rest_api.py
+++ b/python/rest_api.py
@@ -19,22 +19,8 @@ import uvicorn
 
 
 class RestApi(gr.basic_block):
-
-    """ REST endpoints to configure a top block and get status information.
-
-        The following routes are supported as part of the top block in an unauthenticated mode:
-            - GET http://hostname:<port>/status
-            - GET http://hostname:<port>/config
-            - PUT http://hostname:<port>/config
-            - PUT http://hostname:<port>/call
-
-        Args:
-            tbself: This is a reference to the top block self. This gives the rest_api block
-                    access to the variables & callbacks of the top block.
-            port: The desired server listening port.
-            read_settings: List of allowable read-only settings in the top block
-            write_settings: List of allowable write-only settings in the top block
-
+    """
+    See the yaml file for usage docs
     """
 
     def __init__(self, tbself, port, read_settings: List[str] = None, write_settings: List[str] = None):
@@ -49,79 +35,38 @@ class RestApi(gr.basic_block):
             """
             Get the block's readable status settings
             """
+            all_settings = dir(tbself)
+
+            if not read_settings:
+                return {}
 
             read_status = {}
-            all_settings = dir(tbself)
-            if read_settings:
-                for name in read_settings:
-                    if name in all_settings:
-                        read_status[name] = getattr(tbself, name)
-
+            for name in read_settings:
+                if name in all_settings:
+                    read_status[name] = getattr(tbself, name)
             return read_status
 
-        @app.get("/config")
-        def get_config():
-            """
-            Get the block's writeable configuration settings
-            """
-            all_settings = dir(tbself)
-            config = {}
-            if write_settings:
-                for name in write_settings:
-                    if name in all_settings:
-                        config[name] = getattr(tbself, name)
-
-            return config
-
         @app.put("/config")
-        def update_config_settings(
-                settings: dict):
-            """
-            Updates the block's writeable configuration settings
-            """
-            all_settings = dir(tbself)
-
-            if write_settings:
-                for name in settings:
-                    if name not in write_settings or name not in all_settings:
-                        raise HTTPException(
-                            status_code=status.HTTP_400_BAD_REQUEST, \
-                                detail={'Error': f'Setting {name} is not a writeable setting.'})
-                    try:
-                        setattr(tbself, name, settings[name])
-                        return settings
-                    except Exception:
-                        raise HTTPException(
-                            status_code=status.HTTP_400_BAD_REQUEST)
-            else:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED, detail={'Error': f'Could not access writeable settings.'})
-
-        @app.put("/call")
-        def call_by_name(
-                callbacks: dict):
+        def call_by_name(callbacks: dict):
             """
             Executes a callable/writable function in the top block
             """
-            all_settings = dir(tbself)
+            if not write_settings:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                                    detail={'Error': f'No writable settings were provided.'})
 
-            if write_settings:
-                for name in callbacks:
-                    if name not in write_settings:
-                        raise HTTPException(
-                            status_code=status.HTTP_400_BAD_REQUEST, \
-                                detail={'Error': f'Function {name} is not a writeable/callable.'})
-                    try:
-                        func = getattr(tbself, name)
-                        func(callbacks[name])
-                    except Exception:
-                        raise HTTPException(
-                            status_code=status.HTTP_400_BAD_REQUEST, \
-                                detail={'Error': f'Failed to call function {name}.'})
-            else:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED, \
-                        detail={'Error': f'Could not access callable/writable functions.'})
+            for name in callbacks:
+                setter_name = "set_" + name
+                if name not in write_settings:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                        detail={'Error': f'Function {setter_name} is not a writeable/callable.'})
+                try:
+                    # Get the setter that GNU Radio created for that variable, and call it with the new value
+                    func = getattr(tbself, setter_name)
+                    func(callbacks[name])
+                except Exception:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                        detail={'Error': f'Failed to call {setter_name}.'})
 
         self.server_thread = threading.Thread(
             target=uvicorn.run, args=(app,), kwargs={'port': port}, daemon=True)


### PR DESCRIPTION
The old "config" endpoints are gone, I think we determined they weren't actually useful for anything because changing variables of topblock doesn't impact any other blocks unless you also call the setter.  But to become compliant with the platform we are renaming the old "call" to "config".  So now there are just two endpoints, a GET on /status and a PUT on /config.  I actually also added POST on /config, just because it adds flexibility with 1 extra fastapi decorator, but we don't have to mention that in the docs =).  

Secondly, I think it will improve user experience and reduce the "oh crap I didn't realize I had to do that" moments if we add the set_ automatically, just like GNU Radio does when it creates the setter.  So that way you just give it a list of variables and parameters.  At first we thought there would be other functions of topblock we would want to call, like start/stop flowgraph, but after playing around with it, variables/params were the only ones that could actually be called with a single json-serializable value (e.g., the flowgraph handling functions need an event object passed in).  So the only limitation I can think about is if someone wants to create a python flowgraph and add their own custom function, and expose it through REST.  I can't think of why someone might do that, but all they would have to do is start their function name with set_.  Do you think that's a reasonable limitation/hack for the sake of making it more usable for 99% of the use-cases?

Also updated the docs for both of these changes, but the fm recv example in the other repo is going to have to be updated once this gets merged. 

Here's what it looks like now, without the set_ needed:

![image](https://user-images.githubusercontent.com/5722532/169902585-0a3a432d-74cd-4c69-8933-08ad19fb28bb.png)
