### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,11 @@ To get status from a flowgraph, a user can hit the status endpoint as follow
 
 To configure or write the exposed variables, the following command
 
-``curl -X PUT http://<IP>:<port>/config -H 'Content-Type: application/json' -d '{"<variable>":<value>}``
+``curl -X PUT http://<IP>:<port>/config -H 'Content-Type: application/json' -d '{"<variable>":<value>}'``
 
 To execute a callback or function within a top block, use the following route
 
-``curl -X PUT http://<IP>:<port>/call -H 'Content-Type: application/json' -d '{"<function name>":<parameter>}``
+``curl -X PUT http://<IP>:<port>/call -H 'Content-Type: application/json' -d '{"<function name>":<parameter>}'``
 
 For a brief tutorial on using this block, see the [REST API Example](./examples/README.md#rest-api-example).
 


### PR DESCRIPTION
Fixed the curl command so that it can work now, was missing a single quote.